### PR TITLE
Write IP annotations back to Kubernetes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,6 +63,7 @@ func (ctlr *Controller) Run(stopCh <-chan struct{}) {
 					log.Debugf("Controller received %v hosts from Orchestration client.",
 						ipGroup.NumHosts())
 					ctlr.processIPGroups(ipGroup)
+					ctlr.writeIPHosts()
 				} else {
 					log.Error("Controller could not get data from Orchestration client.")
 				}
@@ -174,6 +175,14 @@ func (ctlr *Controller) processIPGroups(ipGroup *orchestration.IPGroup) {
 		}
 	}
 	ctlr.store.DeleteHosts(toRemove)
+}
+
+// Writes the IP addresses and their hosts back to the orchestration
+func (ctlr *Controller) writeIPHosts() {
+	for ip, rec := range ctlr.store.Records {
+		hosts := mapKeys(rec)
+		ctlr.oClient.AnnotateResources(ip, hosts)
+	}
 }
 
 // On startup, refreshes the internal store to match the IPAM system's records

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -93,6 +93,9 @@ func (client *mockOClient) writeIPGroups() {
 	}
 }
 
+// Mock: not used
+func (client *mockOClient) AnnotateResources(ip string, hosts []string) {}
+
 // Mocks the manager client
 type mockIClient struct {
 	manager.Client

--- a/pkg/orchestration/orchestration_test.go
+++ b/pkg/orchestration/orchestration_test.go
@@ -100,6 +100,8 @@ var _ = Describe("Orchestration tests", func() {
 		Expect(ipGroup.NumHosts()).To(Equal(5))
 		Expect(ipGroup.GetAllHosts()).To(Equal(
 			[]string{"bar.com", "baz.com", "foo.com", "foobar.com", "qux.com"}))
+		Expect(ipGroup.getSpecsWithHosts([]string{"foo.com", "bar.com", "baz.com"})).
+			To(Equal([]Spec{spec1, spec2}))
 
 		// Remove host
 		ipGroup.removeHost("qux.com", resourceKey{


### PR DESCRIPTION
Once IPGroups are processed and configured in the IPAM system, the controller loops through its store and has the orchestration client write out the IP addresses to the resources associated with the IP's hosts.