### PR TITLE
Goreportcard fixes

### DIFF
--- a/build-tools/_build-lib.sh
+++ b/build-tools/_build-lib.sh
@@ -37,7 +37,7 @@ if [[ $BUILD_INFO == "" ]]; then
 fi
 
 
-# Defer calculating build dir until actualy in the build environment
+# Defer calculating build dir until actually in the build environment
 get_builddir() {
 # Ensure PWD starts with GOPATH
   if [ "${PWD##$GOPATH}" == "${PWD}" ]; then
@@ -68,7 +68,7 @@ echodo() {
 
 #TODO: Should GOBIN be set too?
 go_install () {
-  # Declare seperate from assign, so failures aren't maked by local
+  # Declare separate from assign, so failures aren't marked by local
   local BUILDDIR
   BUILDDIR=$(get_builddir)
   local GO_BUILD_FLAGS=( -v -ldflags "-extldflags \"-static\" -X main.version=${BUILD_VERSION} -X main.buildInfo=${BUILD_INFO}" )
@@ -108,12 +108,12 @@ gather_coverage() {
 	
   (
     cd $WKDIR/src/github.com/F5Networks
-    gocovmerge `find . -name *.coverprofile` > merged-coverage.out
-    go tool cover -html=merged-coverage.out -o coverage.html
-    go tool cover -func=merged-coverage.out
+    gocovmerge `find . -name *.coverprofile` > coverage.out
+    go tool cover -html=coverage.out -o coverage.html
+    go tool cover -func=coverage.out
     # Total coverage for CI
-    go tool cover -func=merged-coverage.out | grep "^total:" | awk 'END { print "Total coverage:", $3, "of statements" }'
-    rsync -a -f"+ */" -f"+ *.coverprofile" -f"+ coverage.html" -f"+ merged-coverage.out" -f"- *" . $BUILDDIR/coverage
+    go tool cover -func=coverage.out | grep "^total:" | awk 'END { print "Total coverage:", $3, "of statements" }'
+    rsync -a -f"+ */" -f"+ *.coverprofile" -f"+ coverage.html" -f"+ coverage.out" -f"- *" . $BUILDDIR/coverage
   )
 }
 

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -20,8 +20,8 @@ export GOPATH=/build
 
 # push coverage data to coveralls if F5 repo or if configured for fork.
 if [ "$COVERALLS_TOKEN" ]; then
-  cat $BUILDDIR/coverage/merged-coverage.out >> $BUILDDIR/merged-coverage.out
+  cat $BUILDDIR/coverage/coverage.out >> $BUILDDIR/coverage.out
   goveralls \
-    -coverprofile=$BUILDDIR/merged-coverage.out \
+    -coverprofile=$BUILDDIR/coverage.out \
     -service=travis-ci
 fi

--- a/build-tools/version-tool
+++ b/build-tools/version-tool
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Tool for determing and diplaying controller version and build info."""
+"""Tool for determining and diplaying controller version and build info."""
 
 import argparse
 import re

--- a/main.go
+++ b/main.go
@@ -162,11 +162,11 @@ func verifyArgs() error {
 	}
 
 	if len(*orch) == 0 {
-		return fmt.Errorf("Orchestration is required.")
+		return fmt.Errorf("orchestration is required")
 	}
 
 	if len(*mgr) == 0 {
-		return fmt.Errorf("IP-Manager is required.")
+		return fmt.Errorf("ip-manager is required")
 	}
 
 	if *verifyInterval < 0 {
@@ -177,17 +177,17 @@ func verifyArgs() error {
 	*mgr = strings.ToLower(*mgr)
 
 	if len(*namespaces) != 0 && len(*namespaceLabel) != 0 {
-		return fmt.Errorf("Cannot specify both namespace and namespace-label.")
+		return fmt.Errorf("cannot specify both namespace and namespace-label")
 	}
 
 	if *mgr == INFOBLOX {
 		if len(*ibHost) == 0 || len(*ibVersion) == 0 {
-			return fmt.Errorf("Missing required Infoblox parameter.")
+			return fmt.Errorf("missing required Infoblox parameter")
 		} else if (len(*ibUsername) == 0 || len(*ibPassword) == 0) && len(*credsDir) == 0 {
-			return fmt.Errorf("Missing Infoblox credentials.")
+			return fmt.Errorf("missing Infoblox credentials")
 		} else if len(*ibUsername) > 0 && len(*ibPassword) > 0 && len(*credsDir) > 0 {
 			return fmt.Errorf(
-				"Please specify either credentials directory OR username/password, not both.")
+				"please specify either credentials directory OR username/password, not both")
 		}
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,6 +33,7 @@ import (
 const A = "A"
 const CNAME = "CNAME"
 
+// Controller manages communication between the orchestration and ipam system
 type Controller struct {
 	oClient orchestration.Client
 	iClient manager.Client
@@ -44,6 +45,7 @@ type Controller struct {
 	store *ipStore.Store
 }
 
+// NewController creates a Controller object
 func NewController(
 	oClient orchestration.Client,
 	iClient manager.Client,
@@ -59,6 +61,7 @@ func NewController(
 	}
 }
 
+// Run starts up the orchestration client and processes IPGroups as they are received
 func (ctlr *Controller) Run(stopCh <-chan struct{}) {
 	log.Infof("Controller started: (%p)", ctlr)
 

--- a/pkg/manager/infoblox.go
+++ b/pkg/manager/infoblox.go
@@ -44,7 +44,7 @@ type objectManager interface {
 	ReleaseIP(netview, cidr, ipAddr, macAddr string) (string, error)
 }
 
-// Client that the controller uses to talk to Infoblox
+// IBloxClient that the controller uses to talk to Infoblox
 type IBloxClient struct {
 	conn      ibclient.IBConnector
 	objMgr    objectManager
@@ -52,7 +52,7 @@ type IBloxClient struct {
 	ea        ibclient.EA
 }
 
-// Struct to allow NewInfobloxClient to receive all or some parameters
+// InfobloxParams allows NewInfobloxClient to receive all or some parameters
 type InfobloxParams struct {
 	Host     string
 	Version  string
@@ -61,7 +61,7 @@ type InfobloxParams struct {
 	Password string
 }
 
-// Sets up an interface with Infoblox
+// NewInfobloxClient sets up an interface with Infoblox
 func NewInfobloxClient(
 	params *InfobloxParams,
 	cmpType string,
@@ -107,7 +107,7 @@ func NewInfobloxClient(
 	return iClient, nil
 }
 
-// Creates an A record
+// CreateARecord creates a new A record in Infoblox
 func (iClient *IBloxClient) CreateARecord(name, ipAddr, netview string) bool {
 	obj := ibclient.NewRecordA(
 		ibclient.RecordA{
@@ -129,7 +129,7 @@ func (iClient *IBloxClient) CreateARecord(name, ipAddr, netview string) bool {
 	return true
 }
 
-// Deletes an A record and releases the IP address
+// DeleteARecord deletes an A record and releases the IP address
 func (iClient *IBloxClient) DeleteARecord(name, ipAddr, netview, cidr string) {
 	obj := ibclient.NewRecordA(
 		ibclient.RecordA{
@@ -163,7 +163,7 @@ func (iClient *IBloxClient) DeleteARecord(name, ipAddr, netview, cidr string) {
 	iClient.ReleaseAddr(netview, cidr, ipAddr)
 }
 
-// Creates a CNAME record
+// CreateCNAMERecord creates a new CNAME record in Infoblox
 func (iClient *IBloxClient) CreateCNAMERecord(name, canonical, netview string) {
 	obj := ibclient.NewRecordCNAME(
 		ibclient.RecordCNAME{
@@ -184,7 +184,7 @@ func (iClient *IBloxClient) CreateCNAMERecord(name, canonical, netview string) {
 	iClient.recordRef[name] = ref
 }
 
-// Deletes a CNAME record
+// DeleteCNAMERecord deletes a CNAME record from Infoblox
 func (iClient *IBloxClient) DeleteCNAMERecord(name, ipAddr, netview, cidr string) {
 	obj := ibclient.NewRecordCNAME(
 		ibclient.RecordCNAME{
@@ -209,7 +209,7 @@ func (iClient *IBloxClient) DeleteCNAMERecord(name, ipAddr, netview, cidr string
 	}
 }
 
-// Changes an available CNAME to an A record, updates all ensuing CNAMEs
+// CNAMEToA changes an available CNAME to an A record, updates all ensuing CNAMEs
 // in the list to point to the new record
 func (iClient *IBloxClient) CNAMEToA(
 	availHosts []string,
@@ -267,7 +267,7 @@ func (iClient *IBloxClient) CNAMEToA(
 	return aRecord, nil
 }
 
-// Reserves and returns the next available address in the network
+// GetNextAddr reserves and returns the next available address in the network
 func (iClient *IBloxClient) GetNextAddr(netview, cidr string) string {
 	nextAddr, err := iClient.objMgr.AllocateIP(netview, cidr, "", "", "")
 	if err != nil {
@@ -276,12 +276,12 @@ func (iClient *IBloxClient) GetNextAddr(netview, cidr string) string {
 	return ipFromRef(nextAddr.IPAddress)
 }
 
-// Releases an IP address back to Infoblox
+// ReleaseAddr releases an IP address back to Infoblox
 func (iClient *IBloxClient) ReleaseAddr(netview, cidr, ipAddr string) {
 	iClient.objMgr.ReleaseIP(netview, cidr, ipAddr, "")
 }
 
-// Returns the current Infoblox records
+// GetRecords returns the current Infoblox records
 func (iClient *IBloxClient) GetRecords() *store.Store {
 	st := store.NewStore()
 	var zones []ibclient.ZoneAuth

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -18,7 +18,7 @@ package manager
 
 import store "github.com/F5Networks/f5-ipam-ctlr/pkg/store"
 
-// Defines the interface that the IPAM system should implement
+// Client defines the interface that the IPAM system should implement
 type Client interface {
 	// Creates an A record
 	CreateARecord(name, ipAddr, netview string) bool

--- a/pkg/orchestration/kubernetes.go
+++ b/pkg/orchestration/kubernetes.go
@@ -47,10 +47,10 @@ const cidrAnnotation = "ipam.f5.com/network-cidr"
 const hostnameAnnotation = "virtual-server.f5.com/hostname"
 const ipAnnotation = "virtual-server.f5.com/ip"
 
-// The IPAM system being used
+// IPAM system being used
 var IPAM string
 
-// Client that the controller uses to talk to Kubernetes
+// K8sClient that the controller uses to talk to Kubernetes
 type K8sClient struct {
 	// Kubernetes client
 	kubeClient kubernetes.Interface
@@ -79,7 +79,7 @@ type K8sClient struct {
 	channel chan<- bytes.Buffer
 }
 
-// Struct to allow NewKubernetesClient to receive all or some parameters
+// KubeParams allows NewKubernetesClient to receive all or some parameters
 type KubeParams struct {
 	KubeClient     kubernetes.Interface
 	restClient     rest.Interface
@@ -88,7 +88,7 @@ type KubeParams struct {
 	Channel        chan<- bytes.Buffer
 }
 
-// Sets up an interface with Kubernetes
+// NewKubernetesClient sets up an interface with Kubernetes
 func NewKubernetesClient(
 	params *KubeParams,
 ) (*K8sClient, error) {
@@ -164,10 +164,10 @@ func (client *K8sClient) addNamespace(
 
 	if client.watchingAllNamespaces() {
 		return nil, fmt.Errorf(
-			"Cannot add additional namespaces when already watching all.")
+			"cannot add additional namespaces when already watching all")
 	} else if len(client.rsInformers) > 0 && "" == namespace {
 		return nil, fmt.Errorf(
-			"Cannot watch all namespaces when already watching specific ones.")
+			"cannot watch all namespaces when already watching specific ones")
 	}
 	var rsInf *rsInformer
 	var found bool
@@ -188,7 +188,7 @@ func (client *K8sClient) addNamespaceLabelInformer(
 	defer client.informersMutex.Unlock()
 
 	if nil != client.nsInformer {
-		return fmt.Errorf("Already have a namespace label informer added.")
+		return fmt.Errorf("already have a namespace label informer added")
 	}
 	if 0 != len(client.rsInformers) {
 		return fmt.Errorf("Cannot set a namespace label informer when informers " +
@@ -443,7 +443,7 @@ func (client *K8sClient) checkValidIngress(obj interface{}) (bool, *resourceKey)
 	return false, nil
 }
 
-// Runs the client
+// Run starts the kubernetes client, watching for resource updates
 func (client *K8sClient) Run(stopCh <-chan struct{}) {
 	log.Infof("Kubernetes client started: (%p)", client)
 	go client.runImpl(stopCh)
@@ -756,7 +756,7 @@ func (client *K8sClient) writeIPGroups() {
 	}
 }
 
-// Annotates resources that contain given hosts with the given IP address
+// AnnotateResources that contain given hosts with the given IP address
 func (client *K8sClient) AnnotateResources(ip string, hosts []string) {
 	var name, namespace string
 	specsForIP := client.ipGroup.getSpecsWithHosts(hosts)
@@ -819,16 +819,16 @@ func ingHostExists(ing *v1beta1.Ingress, host string) bool {
 			return true
 		}
 		return false
-	} else { // multi-service
-		var hosts []string
-		for _, rule := range ing.Spec.Rules {
-			hosts = append(hosts, rule.Host)
-		}
-		if contains(hosts, host) {
-			return true
-		}
-		return false
 	}
+	// multi-service
+	var hosts []string
+	for _, rule := range ing.Spec.Rules {
+		hosts = append(hosts, rule.Host)
+	}
+	if contains(hosts, host) {
+		return true
+	}
+	return false
 }
 
 func newListWatch(
@@ -860,7 +860,7 @@ func newListWatch(
 	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 }
 
-// Index function that indexes based on an object's name
+// MetaNameIndexFunc indexes based on an object's name
 func MetaNameIndexFunc(obj interface{}) ([]string, error) {
 	meta, err := meta.Accessor(obj)
 	if err != nil {

--- a/pkg/orchestration/kubernetes_test.go
+++ b/pkg/orchestration/kubernetes_test.go
@@ -215,7 +215,8 @@ var _ = Describe("Kubernetes Client tests", func() {
 			Expect(realClient.watchingAllNamespaces()).To(BeFalse())
 
 			// Try adding a namespace label informer (should fail)
-			label, err := labels.Parse("watching")
+			var label labels.Selector
+			label, err = labels.Parse("watching")
 			err = realClient.addNamespaceLabelInformer(label, 0)
 			Expect(err).ToNot(BeNil())
 

--- a/pkg/orchestration/orchestration.go
+++ b/pkg/orchestration/orchestration.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 )
 
-// Defines the interface the orchestration should implement
+// Client defines the interface the orchestration should implement
 type Client interface {
 	// Runs the client, watching for resources
 	Run(stopCh <-chan struct{})
@@ -146,7 +146,7 @@ func (ipGrp *IPGroup) getSpecsWithHosts(hosts []string) []Spec {
 	return specs
 }
 
-// Returns all hosts across IPGroups
+// GetAllHosts returns all hosts across IPGroups
 func (ipGrp *IPGroup) GetAllHosts() []string {
 	var hosts []string
 	for _, grp := range ipGrp.Groups {
@@ -170,7 +170,7 @@ func (ipGrp *IPGroup) getSpec(key resourceKey) (bool, Spec, string) {
 	return false, Spec{}, ""
 }
 
-// Returns the number of total hosts stored
+// NumHosts returns the number of total hosts stored
 func (ipGrp *IPGroup) NumHosts() int {
 	sum := 0
 	for _, grp := range ipGrp.Groups {

--- a/pkg/orchestration/types.go
+++ b/pkg/orchestration/types.go
@@ -19,28 +19,32 @@ package orchestration
 import "sync"
 
 type (
-	// Defines a resource for processing
+	// resourceKey defines a resource for processing
 	resourceKey struct {
 		Kind      string
 		Name      string
 		Namespace string
 	}
 
+	// IPGroup is a struct of IPGroups and a protective mutex
 	IPGroup struct {
 		Groups     IPGroups
 		GroupMutex *sync.Mutex
 	}
+
+	// IPGroups are groups of Specs
 	// Specs in the same group will share an IP address
 	// Specs in the "" (empty string) group will get their own IP addresses
 	IPGroups map[GroupKey][]Spec
 
+	// GroupKey indexes into a group of Specs
 	GroupKey struct {
 		Name    string
 		Netview string
 		Cidr    string
 	}
 
-	// represents a single resource and its hosts
+	// Spec represents a single resource and its hosts
 	Spec struct {
 		Kind      string
 		Name      string

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -18,16 +18,17 @@ package store
 
 import "sort"
 
-// Map of all IP addresses and their corresponding hostnames, netviews, and CIDRs
+// Store is a map of all IP addresses and their corresponding hostnames, netviews, and CIDRs
 type Store struct {
 	Records  map[string]HostSet
 	Netviews map[string]string
 	Cidrs    map[string]string
 }
 
-// Map of hosts (value is record type)
+// HostSet is a map of hosts (value is record type)
 type HostSet map[string]string
 
+// NewStore allocates a new store for the controller
 func NewStore() *Store {
 	var st Store
 	st.Records = make(map[string]HostSet)
@@ -36,7 +37,7 @@ func NewStore() *Store {
 	return &st
 }
 
-// Adds/Updates a record for an IP and hosts
+// AddRecord adds/updates a record for an IP and hosts
 func (st *Store) AddRecord(ip, host, recordType, netview, cidr string) {
 	if _, found := st.Records[ip]; found {
 		if _, ok := st.Records[ip][host]; !ok {
@@ -77,7 +78,7 @@ func (st *Store) deleteHost(delHost string) {
 	}
 }
 
-// Deletes hosts from records
+// DeleteHosts deletes hosts from records
 func (st *Store) DeleteHosts(delHosts []string) {
 	for _, delHost := range delHosts {
 		st.deleteHost(delHost)
@@ -88,17 +89,16 @@ func (st *Store) DeleteHosts(delHosts []string) {
 func (st *Store) getHosts(ip string) []string {
 	var hosts []string
 	if _, found := st.Records[ip]; found {
-		for host, _ := range st.Records[ip] {
+		for host := range st.Records[ip] {
 			hosts = append(hosts, host)
 		}
 		sort.Strings(hosts)
 		return hosts
-	} else {
-		return []string{}
 	}
+	return []string{}
 }
 
-// Returns the IP address for a given host
+// GetIP returns the IP address for a given host
 func (st *Store) GetIP(host string) string {
 	for ip, hosts := range st.Records {
 		if _, ok := hosts[host]; ok {

--- a/test/k8s_utils.go
+++ b/test/k8s_utils.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest/fake"
 )
 
+// NewNamespace creates a Namespace object
 func NewNamespace(name string, labels map[string]string) *v1.Namespace {
 	return &v1.Namespace{
 		TypeMeta: metav1.TypeMeta{
@@ -43,6 +44,7 @@ func NewNamespace(name string, labels map[string]string) *v1.Namespace {
 	}
 }
 
+// NewConfigMap creates a ConfigMap object
 func NewConfigMap(
 	name,
 	namespace string,
@@ -63,6 +65,7 @@ func NewConfigMap(
 	}
 }
 
+// CopyConfigMap copies a ConfigMap object
 func CopyConfigMap(old v1.ConfigMap) *v1.ConfigMap {
 	a := make(map[string]string)
 	for key, value := range old.Annotations {
@@ -76,6 +79,7 @@ func CopyConfigMap(old v1.ConfigMap) *v1.ConfigMap {
 	)
 }
 
+// NewIngress creates an Ingress object
 func NewIngress(
 	name,
 	namespace string,
@@ -96,6 +100,7 @@ func NewIngress(
 	}
 }
 
+// CopyIngress copies an Ingress object
 func CopyIngress(old v1beta1.Ingress) *v1beta1.Ingress {
 	a := make(map[string]string)
 	for key, value := range old.Annotations {


### PR DESCRIPTION
Fixes up the issues/errors exposed by tools used by the goreportcard. These include misspell, ineffassign, and golint.