### PR TITLE
Add license approvals file to support automation of audit check at build time.

### DIFF
--- a/.approvals.json
+++ b/.approvals.json
@@ -1,0 +1,268 @@
+[
+ {
+   "name": "PuerkitoBio/purell",
+   "version": "v1.0.0",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "PuerkitoBio/urlesc",
+   "version": "5bd2802",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "apimachinery",
+   "version": "kubernetes-1.9.3-beta.0-2-g19e3f5a",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "api",
+   "version": "kubernetes-1.10.0-alpha.2",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "client-go",
+   "version": "kubernetes-1.9.3-beta.0",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "crypto",
+   "version": "d172538",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "davecgh/go-spew",
+   "version": "5215b55",
+   "license": "ISC",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "emicklei/go-restful",
+   "version": "v1.2-96-g09691a3",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "ghodss/yaml",
+   "version": "73d445a",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "go-openapi/jsonpointer",
+   "version": "46af16f",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "go-openapi/jsonreference",
+   "version": "13c6e35",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "go-openapi/spec",
+   "version": "6aced65",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "go-openapi/swag",
+   "version": "1d0bd11",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "gogo/protobuf",
+   "version": "v0.5-42-g26de2f9",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "golang/glog",
+   "version": "44145f0",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "golang/protobuf",
+   "version": "0a4f71a",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "google/btree",
+   "version": "e89373f",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "google/gofuzz",
+   "version": "44d8105",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "googleapis/gnostic",
+   "version": "v0.1.0-45-g3a9aa21",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "gregjones/httpcache",
+   "version": "2bcd89a",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "hashicorp/golang-lru",
+   "version": "0a025b7",
+   "license": "MPL 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "howeyc/gopass",
+   "version": "3ca2347",
+   "license": "ISC",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "imdario/mergo",
+   "version": "0.1.3-8-g6633656",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "infobloxopen/infoblox-go-client",
+   "version": "v0.2.0-3-gb812144",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "inf",
+   "version": "v0",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "json-iterator/go",
+   "version": "1.0.5-1-gbca911d",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "juju/ratelimit",
+   "version": "1.0",
+   "license": "LGPLv3",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "kube-openapi",
+   "version": "a07b7bb",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "mailru/easyjson",
+   "version": "d5b7844",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "net",
+   "version": "e90d6d0",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "onsi/ginkgo",
+   "version": "v1.4.0-3-g8382b23",
+   "license": "MIT",
+   "category": 5,
+   "status": "pending"
+ },
+ {
+   "name": "onsi/gomega",
+   "version": "v1.2.0",
+   "license": "MIT",
+   "category": 5,
+   "status": "pending"
+ },
+ {
+   "name": "peterbourgon/diskv",
+   "version": "v2.0.1-4-g2973218",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "sirupsen/logrus",
+   "version": "v1.0.4-2-g768a92a",
+   "license": "MIT",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "spf13/pflag",
+   "version": "9ff6c69",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "sys",
+   "version": "8f0908a",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "text",
+   "version": "2910a50",
+   "license": "BSD 3-clause",
+   "category": 3,
+   "status": "pending"
+ },
+ {
+   "name": "yaml",
+   "version": "v2",
+   "license": "Apache 2.0",
+   "category": 3,
+   "status": "pending"
+ }
+]

--- a/Makefile
+++ b/Makefile
@@ -119,5 +119,5 @@ flatfile_attributions.json: .f5license
 
 docs/_static/ATTRIBUTIONS.md: flatfile_attributions.json  golang_attributions.json
 	./build-tools/attributions-generator.sh \
-		node /frontEnd/frontEnd.js $(CURDIR)
+		node /frontEnd/frontEnd.js --pd $(CURDIR)
 	mv ATTRIBUTIONS.md $@


### PR DESCRIPTION
Problem: There was no automated way to validate if all attributed packages have been approved by LRB.

Solution: The added license approvals file is now used by Attributions Generator to implement the audit check at build time.