### PR TITLE
Remove docker push steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,6 @@ script:
   - set -e
   - if [ "$DOCKER_NAMESPACE" == "" ]; then DOCKER_NAMESPACE="local"; fi
   - BASE_PUSH_TARGET="$DOCKER_NAMESPACE/f5-ipam-ctlr"
-  - |
-    if [ "$DOCKER_P" == "" -o "$DOCKER_U" == "" ]; then
-      echo "[INFO] Docker user or passworde vars absent from travis-ci."
-      echo "[INFO] See README.md section 'build' to configure travis with DockerHub."
-    else
-      docker login -u="$DOCKER_U" -p="$DOCKER_P"
-      DOCKER_READY="true"
-    fi
   - export BUILD_VERSION=$(build-tools/version-tool version)
   - export BUILD_INFO=$(build-tools/version-tool build-info)
   - if [ "$TRAVIS_TAG" == "$TRAVIS_BRANCH" ]; then BUILD_VERSION=$TRAVIS_TAG; fi
@@ -41,17 +33,6 @@ script:
   - export BASE_OS=alpine
   - make verify
   - make prod
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-  - |
-    if [ "$DOCKER_READY" ]; then
-      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
-      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_STAMP"
-      docker push "$IMG_TAG"
-      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker push "$BASE_PUSH_TARGET:$BUILD_STAMP"
-      docker push "$BASE_PUSH_TARGET:latest"
-    fi
   - make docs
   
 deploy:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Contact F5 Technical support via your typical method for more time sensitive cha
 Running
 -------
 
-Official docker images coming soon...
+The official docker image is `f5networks/f5-ipam-ctlr`.
+
+Usually, the controller is deployed in an orchestration environment. However, the controller can be run locally for development testing.
+
+```shell
+docker run f5networks/f5-ipam-ctlr /app/bin/f5-ipam-ctlr <args>
+```
 
 Building
 --------


### PR DESCRIPTION
There is currently no reason for us to push up images to the f5networksdevel repository. If making bug fixes, we can pull down the release image and build locally for incremental changes and testing.