### PR TITLE
Add docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The controller currently supports the following environments:
 Documentation
 -------------
 
-Official documentation coming soon...
+For instruction on how to use this component, see the
+[docs](http://clouddocs.f5.com/products/ipam-ctlr/latest/) for F5 IPAM Controller.
 
 Getting Help
 ------------


### PR DESCRIPTION
Updating the top-level README to contain the link to the docs. This link will work once the docs have been pushed.