### PR TITLE
Remove extra 'v' prefix in docs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ deploy:
       repo: F5Networks/f5-ipam-ctlr
       condition: $TRAVIS_BRANCH == *"-stable" || "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]*
     script:
-      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod ipam-ctlr v$CTLR_VERSION
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod ipam-ctlr $CTLR_VERSION


### PR DESCRIPTION
Problem:
The docs deploy script is deploying changes into 'vvX.Y' instead
of 'vX.Y'.

Solution:
Fixed the travis script to remove the extra 'v' prefix.