### PR TITLE
Pass release and version options into docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,13 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = F5IPAMController
 SOURCEDIR     = .
 BUILDDIR      = _build
+ALLSPHINXOPTS   =
+ifdef DOCS_RELEASE
+  ifdef DOCS_VERSION
+    ALLSPHINXOPTS += -D release=$(DOCS_RELEASE) -D version=$(DOCS_VERSION)
+  endif
+endif
+ALLSPHINXOPTS   += $(SPHINXOPTS)
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -17,4 +24,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(ALLSPHINXOPTS) $(O)


### PR DESCRIPTION
Problem:
Docs are not reporting the correct version on stable branches

Solution:
Passed in the DOCS_RELEASE and DOCS_VERSION env variables into
the docs Makefile in order to override the SPHINX release and version
defaults.